### PR TITLE
Add Kaoto operator to platform manifest

### DIFF
--- a/argocd/platform-applications/templates/kaoto.yaml
+++ b/argocd/platform-applications/templates/kaoto.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kaoto
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: "{{ .Values.gitHost }}/{{ .Values.gitOrg }}/platform-components.git"
+    path: charts/kaoto
+    targetRevision: "{{ .Values.gitRef }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kaoto
+  syncPolicy: {}
+

--- a/charts/kaoto/Chart.yaml
+++ b/charts/kaoto/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: .
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "2.0.1"

--- a/charts/kaoto/templates/kaoto-operator-Kaoto.yaml
+++ b/charts/kaoto/templates/kaoto-operator-Kaoto.yaml
@@ -1,0 +1,12 @@
+apiVersion: designer.kaoto.io/v1alpha1
+kind: Kaoto
+metadata:
+  labels:
+    app.kubernetes.io/created-by: kaoto-operator
+    app.kubernetes.io/instance: kaoto
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kaoto
+    app.kubernetes.io/part-of: kaoto-operator
+  name: kaoto
+  namespace: kaoto
+spec: {}

--- a/charts/kaoto/templates/kaoto-route.yaml
+++ b/charts/kaoto/templates/kaoto-route.yaml
@@ -1,0 +1,26 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: kaoto-app
+  namespace: kaoto
+  labels:
+    app.kubernetes.io/component: designer
+    app.kubernetes.io/instance: kaoto
+    app.kubernetes.io/managed-by: kaoto-operator
+    app.kubernetes.io/name: kaoto
+    app.kubernetes.io/part-of: kaoto
+spec:
+  host: kaoto.{{ .Values.clusterRouterDomain }}
+  to:
+    kind: Service
+    name: kaoto
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None
+status:
+  ingress:
+    - host: kaoto.{{ .Values.clusterRouterDomain }}
+      routerName: default
+      wildcardPolicy: None
+      routerCanonicalHostname: router-default.{{ .Values.clusterRouterDomain }}

--- a/charts/kaoto/values.yaml
+++ b/charts/kaoto/values.yaml
@@ -1,0 +1,1 @@
+clusterRouterDomain: apps.example.cluster.com

--- a/operators/kaoto/kustomization.yaml
+++ b/operators/kaoto/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - subscription.yaml
+  - operatorgroup.yaml

--- a/operators/kaoto/namespace.yaml
+++ b/operators/kaoto/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: Red Hat Developer Hub Operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: kaoto

--- a/operators/kaoto/operatorgroup.yaml
+++ b/operators/kaoto/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kaoto-operator
+  namespace: kaoto
+spec:
+  upgradeStrategy: Default

--- a/operators/kaoto/subscription.yaml
+++ b/operators/kaoto/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/devspaces.openshift-operators: ""
+  name: kaoto
+  namespace: kaoto
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: kaoto-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/operators/kustomization.yaml
+++ b/operators/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - apicurio-designer
   - cert-manager
   - developer-hub
+  - kaoto
   - keycloak
   - microcks
   - openshift-pipelines


### PR DESCRIPTION
There's no relative item in the kanban [board](https://github.com/orgs/contract-first-idp/projects/1/views/7) but we can add one if you agree. 
Kaoto operator for Camel routes design is an easy thing, no connection with GitHub repo is required, we can just play with it and export by the context definition for our purposes.

 