### PR TITLE
Add Hawtio operator to platform manifest

### DIFF
--- a/argocd/platform-applications/templates/hawtio.yaml
+++ b/argocd/platform-applications/templates/hawtio.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hawtio
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: "git@{{ .Values.gitHost }}:{{ .Values.gitOrg }}/{{ .Values.gitProject }}/platform-components"
+    path: charts/hawtio
+    targetRevision: "{{ .Values.gitRef }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m
+

--- a/charts/hawtio/.helmignore
+++ b/charts/hawtio/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hawtio/Chart.yaml
+++ b/charts/hawtio/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: .
+description: A Helm chart for Developer Hub environment configuration using its operator
+type: application
+version: 0.1.0
+appVersion: "1.0.2"

--- a/charts/hawtio/templates/hawtio-online.yaml
+++ b/charts/hawtio/templates/hawtio-online.yaml
@@ -1,0 +1,19 @@
+apiVersion: hawt.io/v1
+kind: Hawtio
+metadata:
+  name: hawtio-online
+  namespace: hawtio-operator
+spec:
+  auth:
+    clientCertCheckSchedule: "* */12 * * *"
+    clientCertExpirationPeriod: 24
+  replicas: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 200Mi
+    requests:
+      cpu: 200m
+      memory: 32Mi
+  type: Cluster
+  version: "1.12"

--- a/charts/hawtio/values.yaml
+++ b/charts/hawtio/values.yaml
@@ -1,0 +1,1 @@
+# no values for this chart yet

--- a/operators/hawtio/kustomization.yaml
+++ b/operators/hawtio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - subscription.yaml
+  - operatorgroup.yaml

--- a/operators/hawtio/namespace.yaml
+++ b/operators/hawtio/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: Red Hat Discovery and management of Java applications deployed on OpenShift
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: hawtio-operator

--- a/operators/hawtio/operatorgroup.yaml
+++ b/operators/hawtio/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: hawtio-operator
+spec:
+  targetNamespaces:
+    - hawtio-operator

--- a/operators/hawtio/subscription.yaml
+++ b/operators/hawtio/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hawtio-operator
+  namespace: hawtio-operator
+spec:
+  channel: stable-v1
+  name: hawtio-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/operators/kustomization.yaml
+++ b/operators/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - apicurio-designer
   - cert-manager
   - developer-hub
+  - hawtio
   - kaoto
   - keycloak
   - microcks


### PR DESCRIPTION
Hawt.io Online Console operator installation for Camel app monitoring through Jolokia agent.
The one from the "_redhat-operator_" source catalog, it seems working fine on Openshift at the moment, I was unable to install the community one. 