### PR TITLE
Add DevSpaces operator to platform manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ GitOps manifest for an Internal Developer Platform built on OpenShift
 Below are the critical configuration parameters that require user-provided values in `argocd/platform-root.yaml`.
 
 
-| Key | Description | Default Value | Notes |
-| --- | ----------- | ------------- | ----- |
-| `clusterRouterDomain` | wildcard domain for the OpenShift Router | `apps.example.cluster.com` | |
-| `gitHost` | GitHub service provider host | `https://github.com` | |
-| `gitOrg` | GitHub organization | `contract-first-idp` | e.g. your fork |
-| `gitRef` | Git branch, tag, or commit | `main` | e.g. your feature branch |
-| `gitToken` | Backstage GitHub authentication token | `ghp_REPLACEME` | Settings -> Developer Settings -> Personal Access Tokens |
+| Key                   | Description                                 | Default Value                           | Notes                                                    |
+|-----------------------|---------------------------------------------|-----------------------------------------|----------------------------------------------------------|
+| `clusterRouterDomain` | wildcard domain for the OpenShift Router    | `apps.example.cluster.com`              |                                                          |
+| `gitHost`             | GitHub service provider host                | `https://github.com`                    |                                                          |
+| `gitOrg`              | GitHub organization                         | `contract-first-idp`                    | e.g. your fork                                           |
+| `gitRef`              | Git branch, tag, or commit                  | `main`                                  | e.g. your feature branch                                 |
+| `gitToken`            | Backstage GitHub authentication token       | `ghp_REPLACEME`                         | Settings -> Developer Settings -> Personal Access Tokens |
+| `eclipseClientId`     | Github registered DevSpaces AppID           | `devSpaceAppID`                         | Settings -> Developer Settings -> OAuth Apps             |
+| `eclipseClientSecret` | Github registered DevSpaces AppSecret       | `devSpaceAppSecret`                     | Settings -> Developer Settings -> OAuth Apps             |   
 
 ## User Guide
 
@@ -60,3 +62,27 @@ Users:
 - `user-dev-2`
 
 All users have an intial password set to: `letmein` 
+
+### Setting config values for DevSpaces 
+
+We need to setup Eclipse-che for installation. Bases on the git provider repo used, we can get the current certificate:
+
+    `openssl s_client -connect github.com:443`
+
+So we can replace in _charts/dev-spaces/templates/self-signed-cert-cm.yaml_ under _custom-git-ca-certificates.pem_, the section between:
+
+    -----BEGIN CERTIFICATE-----
+
+    -----END CERTIFICATE-----
+
+Go to `Settings -> Applications -> Authorized Oauth Apps` in Github User Profile side for creating OAuth DevSpace Authorization, generating ClientID, ClientSecret.
+
+Let set the URL as:
+
+      https://devspaces.apps.cluster-{your-domain}/
+
+Let set the callback URL as:
+
+      https://devspaces.apps.cluster-{your-domain}/api/oauth/callback
+
+Set _eclipseClientId_, and _eclipseClientSecret_, in _platform-root.yaml_ properly, then re-apply again.

--- a/argocd/platform-applications/templates/dev-spaces.yaml
+++ b/argocd/platform-applications/templates/dev-spaces.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-spaces
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: "{{ .Values.gitHost }}/{{ .Values.gitOrg }}/platform-components.git"
+    path: charts/dev-spaces
+    targetRevision: "{{ .Values.gitRef }}"
+    helm:
+      parameters:
+        - name: "auth.eclipseClientId"
+          value: "{{ .Values.eclipseClientId }}"
+        - name: "auth.eclipseClientSecret"
+          value: "{{ .Values.eclipseClientSecret }}"
+        - name: "git.host"
+          value: "{{ .Values.gitHost }}"  
+        - name: "git.token"
+          value: "{{ .Values.gitToken }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/argocd/platform-applications/values.yaml
+++ b/argocd/platform-applications/values.yaml
@@ -11,3 +11,7 @@ authSessionSecret: replaceme
 
 dbUsername: postgres
 dbPassword: dbpw
+
+eclipseClientId: eclipse-che-git-app-id
+eclipseClientSecret: eclipse-che-git-app-secret
+

--- a/argocd/platform-root.example.yaml
+++ b/argocd/platform-root.example.yaml
@@ -31,6 +31,10 @@ spec:
           value: dbpw
         - name: serviceAccountToken
           value: eyXXXXXXX
+        - name: eclipseClientId
+          value: Ov23liriNWMGAfgIwbi4
+        - name: eclipseClientSecret
+          value: 15e9f92990cdb634db74f3f6e7dba7eddf724302
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/charts/dev-spaces/.helmignore
+++ b/charts/dev-spaces/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dev-spaces/Chart.yaml
+++ b/charts/dev-spaces/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: .
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.15.0"

--- a/charts/dev-spaces/templates/checluster.yaml
+++ b/charts/dev-spaces/templates/checluster.yaml
@@ -1,0 +1,62 @@
+apiVersion: org.eclipse.che/v2
+kind: CheCluster
+metadata:
+  annotations:
+    che.eclipse.org/checluster-defaults-cleanup: '{"containers.resources":"true","spec.components.dashboard.headerMessage":"true","spec.components.pluginRegistry.openVSXURL":"true","spec.devEnvironments.defaultComponents":"true","spec.devEnvironments.defaultEditor":"true","spec.devEnvironments.disableContainerBuildCapabilities":"true"}'
+  name: devspaces
+  namespace: devspaces
+  finalizers:
+    - checluster.che.eclipse.org
+    - cluster-resources.finalizers.che.eclipse.org
+    - cheGateway.clusterpermissions.finalizers.che.eclipse.org
+    - oauthclients.finalizers.che.eclipse.org
+    - dashboard.clusterpermissions.finalizers.che.eclipse.org
+spec:
+  components:
+    cheServer:
+      debug: false
+      logLevel: DEBUG
+    dashboard:
+      logLevel: ERROR
+    devWorkspace: {}
+    devfileRegistry: {}
+    imagePuller:
+      enable: false
+      spec: {}
+    metrics:
+      enable: true
+  containerRegistry: {}
+  devEnvironments:
+    containerBuildConfiguration:
+      openShiftSecurityContextConstraint: container-build
+    defaultNamespace:
+      autoProvision: true
+      template: <username>-devspaces
+    maxNumberOfWorkspacesPerUser: -1
+    secondsOfInactivityBeforeIdling: 1800
+    secondsOfRunBeforeIdling: -1
+    security: {}
+    startTimeoutSeconds: 300
+    storage:
+      pvcStrategy: per-user
+      perWorkspaceStrategyPvcConfig:
+        claimSize: 10Gi
+    trustedCerts:
+      gitTrustedCertsConfigMapName: ca-certs-merged
+  gitServices:
+    github:
+    - secretName: github-oauth-config
+      endpoint: https://github.com
+  networking:
+    auth:
+      gateway:
+        configLabels:
+          app: che
+          component: che-gateway-config
+        kubeRbacProxy:
+          logLevel: 0
+        oAuthProxy:
+          cookieExpireSeconds: 86400
+        traefik:
+          logLevel: INFO
+

--- a/charts/dev-spaces/templates/git-access-token-secret.yaml
+++ b/charts/dev-spaces/templates/git-access-token-secret.yaml
@@ -1,0 +1,17 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: personal-access-token-devspace-git
+  namespace: admin-devspaces
+  labels:
+    app.kubernetes.io/component: scm-personal-access-token
+    app.kubernetes.io/part-of: che.eclipse.org
+  annotations:
+    che.eclipse.org/che-userid: admin
+    che.eclipse.org/scm-personal-access-token-name: github
+    che.eclipse.org/scm-url: https://github.com
+data:
+  token: "{{ .Values.git.token | b64enc }}"
+type: Opaque
+
+

--- a/charts/dev-spaces/templates/git-credentials-secret.yaml
+++ b/charts/dev-spaces/templates/git-credentials-secret.yaml
@@ -1,0 +1,21 @@
+{{- $clientID := .Values.auth.eclipseClientId }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: git-credentials-secret
+  namespace: admin-devspaces
+  labels:
+    app.kubernetes.io/component: workspace-secret
+    app.kubernetes.io/part-of: che.eclipse.org
+    controller.devfile.io/git-credential: 'true'
+    controller.devfile.io/watch-secret: 'true'
+  annotations:
+    che.eclipse.org/automount-workspace-secret: 'true'
+    che.eclipse.org/git-credential: 'true'
+    che.eclipse.org/mount-as: file
+    che.eclipse.org/mount-path: /.git-credentials
+    che.eclipse.org/scm-url: 'https://github.com/'
+    controller.devfile.io/mount-path: /.git-credentials
+data:
+  credentials: {{ printf "https://oauth2:%s@github.com" $clientID | b64enc }}
+type: Opaque

--- a/charts/dev-spaces/templates/git-oauth-config.yaml
+++ b/charts/dev-spaces/templates/git-oauth-config.yaml
@@ -1,0 +1,15 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: github-oauth-config
+  namespace: devspaces
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: oauth-scm-configuration
+  annotations:
+    che.eclipse.org/oauth-scm-server: github
+    che.eclipse.org/scm-server-endpoint: https://github.com/
+type: Opaque
+data: 
+  id: "{{ .Values.auth.eclipseClientId | b64enc }}"
+  secret: "{{ .Values.auth.eclipseClientSecret | b64enc }}"

--- a/charts/dev-spaces/templates/self-signed-cert-cm.yaml
+++ b/charts/dev-spaces/templates/self-signed-cert-cm.yaml
@@ -1,0 +1,35 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: che-git-self-signed-cert
+  namespace: devspaces
+  labels:
+    app.kubernetes.io/component: ca-bundle
+    app.kubernetes.io/part-of: che.eclipse.org
+data:
+  custom-git-ca-certificates.pem: |
+    -----BEGIN CERTIFICATE-----
+    MIIDWjCCAkICCQCp02w1pasYDjANBgkqhkiG9w0BAQUFADBvMQswCQYDVQQGEwJG
+    UjEPMA0GA1UECBMGQWxzYWNlMRMwEQYDVQQHEwpTdHJhc2JvdXJnMRgwFgYDVQQK
+    Ew93d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsTB2xpYmZzY3AxDjAMBgNVBAMTBWFs
+    aWNlMB4XDTExMDQyODA4MjM0MVoXDTIxMDQyNTA4MjM0MVowbzELMAkGA1UEBhMC
+    RlIxDzANBgNVBAgTBkFsc2FjZTETMBEGA1UEBxMKU3RyYXNib3VyZzEYMBYGA1UE
+    ChMPd3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLEwdsaWJmc2NwMQ4wDAYDVQQDEwVh
+    bGljZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANibOdleRebXSssm
+    gg++gB/vpuWyJDpHZnN+0ZNC4kfmnH4JZ1ddKtrHonVL6dWNLbb1xjs6LFJHFlhl
+    YvB3e/+AyjuJyWLmPsVPEnCqohwPIUv6I2PxG8xLIkMPDQHOej0C28ylGvXiAJmh
+    SsGDvgLWBBzQU5588/qVdTP3OWLjdYb6LTV22i7vm8ouL8mODOc9vsyM8UrzaGjq
+    2P/sOchkyUIfTWfUG44ieFUcNZZ7U3Tv4TPvAwU53mO79MonOKcsFdr22YDWMTE4
+    j/SuHpq7KMDsdqu0keExqx+NJ4bJ/Qk/HeRLL5qqftQaU/UTefYTwwNPGYr35xH7
+    Hpd56b0CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAlTEbe2gCNHA1oRXsHOaF4sm/
+    +fz9zs6VWDukuZdjggnMK+9ZHBioGTUUWHWI53tbvFVr1GwQ6V+hi/iPqFTkdtir
+    0QErPDqh32MWXG00AItxSFQIfu87MggMnVpBYNBOEu3kmWHGWu/pmQ59cYzLM4j4
+    s2kpqPhw02gCReN8H6izO0w483foO78V2PSNOPUlQfkY9bM2CQjYLhReR0X/b+1q
+    MJHdZzY/UyyziXkUplbnuKknRFV0nVwVUdXqGKXgaV6ypfBz1xtDpk30SAx6rn9C
+    C6ZaXlQkDZ+Sfh4FkYf0VUspJCifVt8LWdQOzRhcODH/PsDVhjssXtKkL7HAcg==
+    -----END CERTIFICATE-----
+
+  
+  
+    
+  

--- a/charts/dev-spaces/templates/ws-gitconfig-cm.yaml
+++ b/charts/dev-spaces/templates/ws-gitconfig-cm.yaml
@@ -1,0 +1,23 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: workspace-userdata-gitconfig-configmap
+  namespace: admin-devspaces
+  labels:
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-configmap: 'true'
+  annotations:
+    controller.devfile.io/mount-as: subpath
+    controller.devfile.io/mount-path: /etc/
+data:
+  gitconfig: |
+    [filter "lfs"]
+      clean=git-lfs clean -- %f
+      smudge=git-lfs smudge -- %f
+      process=git-lfs filter-process
+      required=true
+    [user]
+      email = backstage-admin@redhat.com
+      name = admin
+    [http]
+      sslCAInfo=/public-certs/che-git-self-signed-cert.custom-git-ca-certificates.pem

--- a/charts/dev-spaces/templates/ws-preferences-cm.yaml
+++ b/charts/dev-spaces/templates/ws-preferences-cm.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: workspace-preferences-configmap
+  namespace: admin-devspaces
+data:
+  skip-authorization: '[]'

--- a/charts/dev-spaces/values.yaml
+++ b/charts/dev-spaces/values.yaml
@@ -1,0 +1,8 @@
+clusterRouterDomain: example.cluster.com
+auth:
+  eclipseClientId: devspaceAppID
+  eclipseClientSecret: devspaceClientSecret
+git:
+  host: git-host
+  token: replaceme
+

--- a/operators/dev-spaces/kustomization.yaml
+++ b/operators/dev-spaces/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml
+  - operatorgroup.yaml
+  - namespace.yaml
+  - workspace.yaml
+

--- a/operators/dev-spaces/namespace.yaml
+++ b/operators/dev-spaces/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: devspaces

--- a/operators/dev-spaces/operatorgroup.yaml
+++ b/operators/dev-spaces/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+  name: devspaces
+  namespace: devspaces
+spec:
+  targetNamespaces:

--- a/operators/dev-spaces/subscription.yaml
+++ b/operators/dev-spaces/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/devspaces.openshift-operators: ""
+  name: devspaces
+  namespace: devspaces
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: devspaces
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/operators/dev-spaces/workspace.yaml
+++ b/operators/dev-spaces/workspace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: admin-devspaces

--- a/operators/kustomization.yaml
+++ b/operators/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - apicurio-designer
   - cert-manager
+  - dev-spaces
   - developer-hub
   - hawtio
   - kaoto


### PR DESCRIPTION
Currently I have not been found capable of externalizing this [certificate](https://github.com/smongiar/platform-components/blob/devspaces-operator/charts/dev-spaces/templates/self-signed-cert-cm.yaml#L11-L30), which however, does not seem to me to be sensitive data. So it can also be hardcoded, the problem is that I would have liked to make it configurable, because it can change. In any case, the procedure for any generation is described in this section of the [README](https://github.com/smongiar/platform-components/blob/devspaces-operator/README.md#setting-config-values-for-devspaces).

I also talked about it with @rohittaneja0 , maybe in the future he could help me set a `_fileParameters_` in the argo [manifest](https://github.com/smongiar/platform-components/blob/devspaces-operator/argocd/platform-applications/templates/dev-spaces.yaml#L13) of DevSpaces, as reported [here](https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/) 
