### PR TITLE
Upgrades rhdh-operator starting CSV

### DIFF
--- a/operators/developer-hub/subscription.yaml
+++ b/operators/developer-hub/subscription.yaml
@@ -11,4 +11,4 @@ spec:
   name: rhdh
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhdh-operator.v1.2.5
+  startingCSV: rhdh-operator.v1.2.6


### PR DESCRIPTION
on OCP 4.17.7 the Red Hat Developer Hub Operator doesn't work anymore with starting CSV `1.2.5`, it requires to be updated to `1.2.6`