### PR TITLE
Automatically configure Backstage k8s service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ GitOps manifest for an Internal Developer Platform built on OpenShift
 | `gitOrg` | GitHub organization | `contract-first-idp` | e.g. your fork |
 | `gitRef` | Git branch, tag, or commit | `main` | e.g. your feature branch |
 | `gitToken` | Backstage GitHub authentication token | `ghp_REPLACEME` | Settings -> Developer Settings -> Personal Access Tokens |
-| `serviceAccountToken` | Backstage k8s authentication token | `eyREPLACEME` | See [Backstage K8s Integration Docs](https://backstage.io/docs/features/kubernetes/configuration#clustersserviceaccounttoken-optional)
 | `eclipseClientId` | Github registered DevSpaces AppID | `devSpaceAppID` | See [Configuring a GitHub App for DevSpaces]([#configuring-a-github-app-for-devspaces](https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/3.16/html/administration_guide/configuring-devspaces#configuring-oauth-2-for-github)) |
 | `eclipseClientSecret` | Github registered DevSpaces AppSecret | `devSpaceAppSecret` | See [Configuring a GitHub App for DevSpaces](https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/3.16/html/administration_guide/configuring-devspaces#configuring-oauth-2-for-github) |
 

--- a/argocd/platform-applications/values.yaml
+++ b/argocd/platform-applications/values.yaml
@@ -1,6 +1,6 @@
 # See argocd/platform-root.yaml for overrides
 clusterRouterDomain: apps.example.cluster.com
-serviceAccountToken: eyREPLACEME
+
 
 gitHost: https://github.com
 gitOrg: contract-first-idp
@@ -15,3 +15,5 @@ authSessionSecret: Q72XbDKY8IcNSNzAQjVwa3xmh4lfdvzG
 
 dbUsername: postgres
 dbPassword: dbpw
+
+serviceAccountToken: deprecated

--- a/argocd/platform-root.example.yaml
+++ b/argocd/platform-root.example.yaml
@@ -21,8 +21,6 @@ spec:
           value: main
         - name: gitToken
           value: ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-        - name: serviceAccountToken
-          value: eyXXXXXXX
         - name: eclipseClientId
           value: xxxxxxxxxxxxxxxxxxxx
         - name: eclipseClientSecret

--- a/charts/developer-hub/templates/backstage.yaml
+++ b/charts/developer-hub/templates/backstage.yaml
@@ -17,6 +17,8 @@ spec:
           value: '0'
       secrets:
         - name: rhdh-secrets
+        - name: backstage-cluster-viewer-token
+          key: token
     extraFiles:
       mountPath: extraFiles
       configMaps:

--- a/charts/developer-hub/templates/rhdh-app-config.yaml
+++ b/charts/developer-hub/templates/rhdh-app-config.yaml
@@ -40,7 +40,7 @@ data:
         - clusters:
           - authProvider: serviceAccount
             name: ${K8S_CLUSTER_NAME}
-            serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+            serviceAccountToken: ${token}
             url: ${K8S_CLUSTER_URL}
             skipTLSVerify: true
           type: config

--- a/charts/developer-hub/templates/rhdh-secrets.yaml
+++ b/charts/developer-hub/templates/rhdh-secrets.yaml
@@ -10,6 +10,5 @@ stringData:
   KEYCLOAK_CLIENT_SECRET: "{{ .Values.auth.clientSecret }}"
   GIT_TOKEN: "{{ .Values.git.token }}"
   K8S_CLUSTER_NAME: "development-cluster"
-  K8S_CLUSTER_TOKEN: "{{ .Values.serviceAccountToken }}"
   K8S_CLUSTER_URL: "https://{{ .Values.clusterApiDomain }}:6443"
 type: Opaque

--- a/charts/developer-hub/templates/service-account-role-binding.yaml
+++ b/charts/developer-hub/templates/service-account-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-cluster-viewer-binding
+subjects:
+  - kind: ServiceAccount
+    name: backstage-cluster-viewer
+    namespace: developer-hub
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/developer-hub/templates/service-account-token.yaml
+++ b/charts/developer-hub/templates/service-account-token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-cluster-viewer-token
+  annotations:
+    kubernetes.io/service-account.name: "backstage-cluster-viewer"
+type: kubernetes.io/service-account-token

--- a/charts/developer-hub/templates/service-account.yaml
+++ b/charts/developer-hub/templates/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage-cluster-viewer

--- a/charts/developer-hub/values.yaml
+++ b/charts/developer-hub/values.yaml
@@ -1,6 +1,6 @@
 clusterRouterDomain: example.cluster.com
 clusterApiDomain: api.example.cluster.com
-serviceAccountToken: replaceme
+
 auth:
   sessionSecret: Q72XbDKY8IcNSNzAQjVwa3xmh4lfdvzG
   keycloakUrl: https://keycloak.example.com


### PR DESCRIPTION
This PR configures a service account token declaratively instead of asking the user to configure and provide a token as a configuration value. This will more reliably configure the Backstage k8s-related plugins out-of-the box, as well as remove a requirement for installation. 